### PR TITLE
Use Config::$url when User::isIncluded() method is run

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -60,7 +60,7 @@ class User
             }
         }
 
-        if ($experiment->url && !Util::urlIsValid($experiment->url)) {
+        if ($experiment->url && !Util::urlIsValid($experiment->url, $this->client->config->url)) {
             return false;
         }
 


### PR DESCRIPTION
So this changes the client's environment for the current request URL. This utilization is useful when calling an API endpoint to resolve an experiment based on the passed $url parameter instead of checking the current request URL.